### PR TITLE
TEAM-308 Убрать конфликт макросов в syslog.h и userver

### DIFF
--- a/src/Java/SyslogJavaAdapter/JavaAdapter.cpp
+++ b/src/Java/SyslogJavaAdapter/JavaAdapter.cpp
@@ -1,6 +1,6 @@
 #include <stdio.h>
-#include <syslog.h>
 
+#include <Logger/SyslogAdapter.hpp>
 #include <String/StringManip.hpp>
 #include <JavaCommons/JavaCommons.hpp>
 #include <SyslogJavaAdapter/JavaAdapter.hpp>

--- a/src/Logger/Syslog.cpp
+++ b/src/Logger/Syslog.cpp
@@ -1,8 +1,8 @@
+#include <Logger/Syslog.hpp>
+
 #include <Generics/Function.hpp>
 
 #include <Stream/MemoryStream.hpp>
-
-#include <Logger/Syslog.hpp>
 
 
 namespace Logging
@@ -103,14 +103,14 @@ namespace Logging
   
           static const int CONVERT_TO_SYSLOG_SEVERITY[] =
           {
-            LOG_ALERT, LOG_ALERT, LOG_CRIT, LOG_ERR, LOG_WARNING,
-            LOG_NOTICE, LOG_INFO
+            LOG_ALERT, LOG_ALERT, LOG_CRIT, LOG_ERR, SYSLOG_LOG_WARNING,
+            LOG_NOTICE, SYSLOG_LOG_INFO
           };
 
           int priority =
             (record.severity < sizeof(CONVERT_TO_SYSLOG_SEVERITY) 
               / sizeof(CONVERT_TO_SYSLOG_SEVERITY[0]) ?
-                CONVERT_TO_SYSLOG_SEVERITY[record.severity] : LOG_DEBUG);
+                CONVERT_TO_SYSLOG_SEVERITY[record.severity] : SYSLOG_LOG_DEBUG);
 
           syslog(priority, "%s", str);
         }

--- a/src/Logger/Syslog.hpp
+++ b/src/Logger/Syslog.hpp
@@ -6,9 +6,8 @@
 #ifndef LOGGER_SYS_LOGGER_HPP
 #define LOGGER_SYS_LOGGER_HPP
 
-#include <syslog.h>
-
 #include <Logger/SimpleLogger.hpp>
+#include <Logger/SyslogAdapter.hpp>
 
 
 namespace Logging

--- a/src/Logger/SyslogAdapter.hpp
+++ b/src/Logger/SyslogAdapter.hpp
@@ -1,0 +1,14 @@
+#ifndef LOGGER_SYSLOG_ADAPTER_HPP
+#define LOGGER_SYSLOG_ADAPTER_HPP
+
+#include <syslog.h>
+
+static const auto SYSLOG_LOG_DEBUG = LOG_DEBUG;
+static const auto SYSLOG_LOG_INFO = LOG_INFO;
+static const auto SYSLOG_LOG_WARNING = LOG_WARNING;
+
+#undef LOG_DEBUG
+#undef LOG_INFO
+#undef LOG_WARNING
+
+#endif


### PR DESCRIPTION
Убрал конфлик макросов путём undefine пересекающихся имён из <syslog.h> внутри файла SyslogAdapter.hpp.